### PR TITLE
fix: indent Python script in block scalar to fix YAML parse error

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,65 +44,65 @@ jobs:
           VERSION: ${{ matrix.version }}
         run: |
           python3 << 'PYEOF'
-import os, re
+          import os, re
 
-with open("bench_output.txt") as f:
-    content = f.read()
+          with open("bench_output.txt") as f:
+              content = f.read()
 
-entries = []
-current_name = None
-current_time_min = current_time_mean = current_time_max = None
-current_chg_min = current_chg_mean = current_chg_max = None
-skip_prefixes = ("Found", "Warning", "Benchmarking", "Gnuplot", "criterion", "Generating", "Baseline")
+          entries = []
+          current_name = None
+          current_time_min = current_time_mean = current_time_max = None
+          current_chg_min = current_chg_mean = current_chg_max = None
+          skip_prefixes = ("Found", "Warning", "Benchmarking", "Gnuplot", "criterion", "Generating", "Baseline")
 
-def flush_entry():
-    if current_name is not None and current_time_min:
-        entries.append((current_name, current_time_min, current_time_mean, current_time_max,
-                        current_chg_min, current_chg_mean, current_chg_max))
+          def flush_entry():
+              if current_name is not None and current_time_min:
+                  entries.append((current_name, current_time_min, current_time_mean, current_time_max,
+                                  current_chg_min, current_chg_mean, current_chg_max))
 
-for line in content.split("\n"):
-    stripped = line.strip()
-    if not stripped:
-        continue
-    if not line.startswith((" ", "\t")) and re.match(r"^[a-zA-Z_]", stripped) and not any(stripped.startswith(p) for p in skip_prefixes):
-        flush_entry()
-        current_name = stripped
-        current_time_min = current_time_mean = current_time_max = None
-        current_chg_min = current_chg_mean = current_chg_max = None
-    elif stripped.startswith("time:") and "[" in stripped and current_name:
-        m = re.search(r"\[([\d.]+\s+\S+)\s+([\d.]+\s+\S+)\s+([\d.]+\s+\S+)\]", stripped)
-        if m:
-            current_time_min, current_time_mean, current_time_max = m.group(1), m.group(2), m.group(3)
-    elif stripped.startswith("change:") and "[" in stripped and current_name:
-        m = re.search(r"\[([+-][\d.]+%)\s+([+-][\d.]+%)\s+([+-][\d.]+%)\]", stripped)
-        if m:
-            current_chg_min, current_chg_mean, current_chg_max = m.group(1), m.group(2), m.group(3)
+          for line in content.split("\n"):
+              stripped = line.strip()
+              if not stripped:
+                  continue
+              if not line.startswith((" ", "\t")) and re.match(r"^[a-zA-Z_]", stripped) and not any(stripped.startswith(p) for p in skip_prefixes):
+                  flush_entry()
+                  current_name = stripped
+                  current_time_min = current_time_mean = current_time_max = None
+                  current_chg_min = current_chg_mean = current_chg_max = None
+              elif stripped.startswith("time:") and "[" in stripped and current_name:
+                  m = re.search(r"\[([\d.]+\s+\S+)\s+([\d.]+\s+\S+)\s+([\d.]+\s+\S+)\]", stripped)
+                  if m:
+                      current_time_min, current_time_mean, current_time_max = m.group(1), m.group(2), m.group(3)
+              elif stripped.startswith("change:") and "[" in stripped and current_name:
+                  m = re.search(r"\[([+-][\d.]+%)\s+([+-][\d.]+%)\s+([+-][\d.]+%)\]", stripped)
+                  if m:
+                      current_chg_min, current_chg_mean, current_chg_max = m.group(1), m.group(2), m.group(3)
 
-flush_entry()
+          flush_entry()
 
-def verdict(mean_chg):
-    if mean_chg is None:
-        return "—"
-    v = float(mean_chg.rstrip("%"))
-    if v < -0.5:
-        return "improvement"
-    elif v > 0.5:
-        return "regression"
-    else:
-        return "~ no change"
+          def verdict(mean_chg):
+              if mean_chg is None:
+                  return "—"
+              v = float(mean_chg.rstrip("%"))
+              if v < -0.5:
+                  return "improvement"
+              elif v > 0.5:
+                  return "regression"
+              else:
+                  return "~ no change"
 
-summary_path = os.environ["GITHUB_STEP_SUMMARY"]
-with open(summary_path, "a") as f:
-    f.write(f"## Benchmark Results ({os.environ['VERSION']})\n\n")
-    f.write("| Benchmark | Min | Mean | Max | Delta | Verdict |\n")
-    f.write("|---|---|---|---|---|---|\n")
-    for name, mn, mean, mx, chg_min, chg_mean, chg_max in entries:
-        if chg_mean:
-            delta = f"{chg_min} / {chg_mean} / {chg_max}"
-        else:
-            delta = "—"
-        f.write(f"| {name} | {mn} | {mean} | {mx} | {delta} | {verdict(chg_mean)} |\n")
-PYEOF
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+          with open(summary_path, "a") as f:
+              f.write(f"## Benchmark Results ({os.environ['VERSION']})\n\n")
+              f.write("| Benchmark | Min | Mean | Max | Delta | Verdict |\n")
+              f.write("|---|---|---|---|---|---|\n")
+              for name, mn, mean, mx, chg_min, chg_mean, chg_max in entries:
+                  if chg_mean:
+                      delta = f"{chg_min} / {chg_mean} / {chg_max}"
+                  else:
+                      delta = "—"
+                  f.write(f"| {name} | {mn} | {mean} | {mx} | {delta} | {verdict(chg_mean)} |\n")
+          PYEOF
       - uses: actions/upload-artifact@v4
         with:
           name: report ${{ matrix.version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,6 @@ jobs:
       - name: run benchmark (initial)
         if: steps.download-baseline.outcome != 'success'
         run: cargo bench -- --save-baseline baseline 2>&1 | tee bench_output.txt
-
       - name: tabularize results
         env:
           VERSION: ${{ matrix.version }}
@@ -104,7 +103,6 @@ with open(summary_path, "a") as f:
             delta = "—"
         f.write(f"| {name} | {mn} | {mean} | {mx} | {delta} | {verdict(chg_mean)} |\n")
 PYEOF
-
       - uses: actions/upload-artifact@v4
         with:
           name: report ${{ matrix.version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/liberocks/lowdash"
 readme = "README.md"
 license = "MIT"
 categories = ["rust-patterns"]
-keywords = ["rust-lodash", "lodash", "utility", "js", "javascript"]
+keywords = ["rust-lodash", "lodash", "utility"]
 edition = "2021"
 autobenches = false
 

--- a/benches/assign.rs
+++ b/benches/assign.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_assign(c: &mut Criterion) {
-    let maps = support::numeric_maps(8, 256);
-    c.bench_function("assign", |b| b.iter(|| ld::assign(black_box(&maps))));
+    let small = support::numeric_maps(8, 256);
+    c.bench_function("assign/small", |b| b.iter(|| ld::assign(black_box(&small))));
+
+    let large = support::numeric_maps(32, 1024);
+    c.bench_function("assign/large", |b| b.iter(|| ld::assign(black_box(&large))));
 }

--- a/benches/associate.rs
+++ b/benches/associate.rs
@@ -3,12 +3,32 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_associate(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("associate", |b| {
+    let collection = support::people(4_096);
+    c.bench_function("associate/people/increasing", |b| {
         b.iter(|| {
             ld::associate(
                 black_box(&collection),
                 black_box(|person: &support::Person| (person.id, person.age)),
+            )
+        })
+    });
+
+    let shuffled = support::people_shuffled(4_096);
+    c.bench_function("associate/people/shuffled", |b| {
+        b.iter(|| {
+            ld::associate(
+                black_box(&shuffled),
+                black_box(|person: &support::Person| (person.id, person.age)),
+            )
+        })
+    });
+
+    let timed_records = support::timed_records(4_096);
+    c.bench_function("associate/timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::associate(
+                black_box(&timed_records),
+                black_box(|record: &support::TimedRecord| (record.id, record.timestamp)),
             )
         })
     });

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -132,7 +132,10 @@ mod values;
 mod words;
 
 fn custom_criterion() -> Criterion {
-    Criterion::default().output_directory(std::path::Path::new("./report"))
+    Criterion::default()
+        .output_directory(std::path::Path::new("./report"))
+        .sample_size(500)
+        .measurement_time(std::time::Duration::from_secs(10))
 }
 
 fn all_benches(c: &mut Criterion) {

--- a/benches/camel_case.rs
+++ b/benches/camel_case.rs
@@ -4,7 +4,17 @@ use lowdash as ld;
 
 pub fn benchmark_camel_case(c: &mut Criterion) {
     let input = support::mixed_identifier();
-    c.bench_function("camel_case", |b| {
+    c.bench_function("camel_case/mixed_identifier", |b| {
         b.iter(|| ld::camel_case(black_box(input)))
+    });
+
+    let sentence = support::long_sentence();
+    c.bench_function("camel_case/long_sentence", |b| {
+        b.iter(|| ld::camel_case(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("camel_case/short", |b| {
+        b.iter(|| ld::camel_case(black_box(short)))
     });
 }

--- a/benches/capitalize.rs
+++ b/benches/capitalize.rs
@@ -3,8 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_capitalize(c: &mut Criterion) {
-    let input = support::long_sentence();
-    c.bench_function("capitalize", |b| {
+    let sentence = support::long_sentence();
+    c.bench_function("capitalize/long_sentence", |b| {
+        b.iter(|| ld::capitalize(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("capitalize/short", |b| {
+        b.iter(|| ld::capitalize(black_box(short)))
+    });
+
+    let input = support::mixed_identifier();
+    c.bench_function("capitalize/mixed_identifier", |b| {
         b.iter(|| ld::capitalize(black_box(input)))
     });
 }

--- a/benches/char_length.rs
+++ b/benches/char_length.rs
@@ -3,8 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_char_length(c: &mut Criterion) {
-    let input = support::long_sentence();
-    c.bench_function("char_length", |b| {
+    let sentence = support::long_sentence();
+    c.bench_function("char_length/long_sentence", |b| {
+        b.iter(|| ld::char_length(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("char_length/short", |b| {
+        b.iter(|| ld::char_length(black_box(short)))
+    });
+
+    let input = support::mixed_identifier();
+    c.bench_function("char_length/mixed_identifier", |b| {
         b.iter(|| ld::char_length(black_box(input)))
     });
 }

--- a/benches/chunk.rs
+++ b/benches/chunk.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_chunk(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("chunk", |b| {
-        b.iter(|| ld::chunk(black_box(&collection), black_box(32)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("chunk/int_vec/32", |b| {
+        b.iter(|| ld::chunk(black_box(&ints), black_box(32)))
+    });
+
+    c.bench_function("chunk/int_vec/128", |b| {
+        b.iter(|| ld::chunk(black_box(&ints), black_box(128)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("chunk/float_vec/32", |b| {
+        b.iter(|| ld::chunk(black_box(&floats), black_box(32)))
     });
 }

--- a/benches/chunk_string.rs
+++ b/benches/chunk_string.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_chunk_string(c: &mut Criterion) {
-    let input = support::long_sentence();
-    c.bench_function("chunk_string", |b| {
-        b.iter(|| ld::chunk_string(black_box(input), black_box(12)))
+    let sentence = support::long_sentence();
+    c.bench_function("chunk_string/long_sentence/12", |b| {
+        b.iter(|| ld::chunk_string(black_box(sentence), black_box(12)))
+    });
+
+    c.bench_function("chunk_string/long_sentence/5", |b| {
+        b.iter(|| ld::chunk_string(black_box(sentence), black_box(5)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("chunk_string/short/3", |b| {
+        b.iter(|| ld::chunk_string(black_box(short), black_box(3)))
     });
 }

--- a/benches/clamp.rs
+++ b/benches/clamp.rs
@@ -2,7 +2,19 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_clamp(c: &mut Criterion) {
-    c.bench_function("clamp", |b| {
+    c.bench_function("clamp/i32/within", |b| {
         b.iter(|| ld::clamp(black_box(123_i32), black_box(-10_i32), black_box(90_i32)))
+    });
+
+    c.bench_function("clamp/i32/below", |b| {
+        b.iter(|| ld::clamp(black_box(-50_i32), black_box(-10_i32), black_box(90_i32)))
+    });
+
+    c.bench_function("clamp/i32/above", |b| {
+        b.iter(|| ld::clamp(black_box(999_i32), black_box(-10_i32), black_box(90_i32)))
+    });
+
+    c.bench_function("clamp/f64/within", |b| {
+        b.iter(|| ld::clamp(black_box(3.14_f64), black_box(0.0_f64), black_box(10.0_f64)))
     });
 }

--- a/benches/combination.rs
+++ b/benches/combination.rs
@@ -3,7 +3,16 @@ use lowdash as ld;
 
 pub fn benchmark_combination(c: &mut Criterion) {
     let items: Vec<i32> = (0..18).collect();
-    c.bench_function("combination", |b| {
+    c.bench_function("combination/18-choose-3", |b| {
         b.iter(|| ld::combination(black_box(&items), black_box(3)))
+    });
+
+    c.bench_function("combination/18-choose-2", |b| {
+        b.iter(|| ld::combination(black_box(&items), black_box(2)))
+    });
+
+    let small: Vec<i32> = (0..8).collect();
+    c.bench_function("combination/8-choose-3", |b| {
+        b.iter(|| ld::combination(black_box(&small), black_box(3)))
     });
 }

--- a/benches/common_ceil_log2.rs
+++ b/benches/common_ceil_log2.rs
@@ -2,7 +2,15 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_common_ceil_log2(c: &mut Criterion) {
-    c.bench_function("common_ceil_log2", |b| {
+    c.bench_function("common_ceil_log2/65537", |b| {
         b.iter(|| ld::common::ceil_log2(black_box(65_537)))
+    });
+
+    c.bench_function("common_ceil_log2/1", |b| {
+        b.iter(|| ld::common::ceil_log2(black_box(1)))
+    });
+
+    c.bench_function("common_ceil_log2/1024", |b| {
+        b.iter(|| ld::common::ceil_log2(black_box(1024)))
     });
 }

--- a/benches/common_is_collection_float.rs
+++ b/benches/common_is_collection_float.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_common_is_collection_float(c: &mut Criterion) {
-    let collection = support::boxed_float_any(1_024);
-    c.bench_function("common_is_collection_float", |b| {
-        b.iter(|| ld::common::is_collection_float(black_box(&collection)))
+    let floats = support::boxed_float_any(1_024);
+    c.bench_function("common_is_collection_float/1k", |b| {
+        b.iter(|| ld::common::is_collection_float(black_box(&floats)))
+    });
+
+    let large = support::boxed_float_any(4_096);
+    c.bench_function("common_is_collection_float/4k", |b| {
+        b.iter(|| ld::common::is_collection_float(black_box(&large)))
     });
 }

--- a/benches/common_is_floats.rs
+++ b/benches/common_is_floats.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_common_is_floats(c: &mut Criterion) {
-    c.bench_function("common_is_floats", |b| {
+    c.bench_function("common_is_floats/f64", |b| {
         b.iter(|| black_box(ld::common::is_floats::<f64>()))
+    });
+
+    c.bench_function("common_is_floats/i32", |b| {
+        b.iter(|| black_box(ld::common::is_floats::<i32>()))
     });
 }

--- a/benches/common_random_usize.rs
+++ b/benches/common_random_usize.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_common_random_usize(c: &mut Criterion) {
-    c.bench_function("common_random_usize", |b| {
+    c.bench_function("common_random_usize/10000", |b| {
         b.iter(|| ld::common::random_usize(black_box(10_000)))
+    });
+
+    c.bench_function("common_random_usize/2", |b| {
+        b.iter(|| ld::common::random_usize(black_box(2)))
     });
 }

--- a/benches/common_random_usize_with_seed.rs
+++ b/benches/common_random_usize_with_seed.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_common_random_usize_with_seed(c: &mut Criterion) {
-    c.bench_function("common_random_usize_with_seed", |b| {
+    c.bench_function("common_random_usize_with_seed/10000", |b| {
         b.iter(|| ld::common::random_usize_with_seed(black_box(10_000), black_box(0x5eed_u64)))
+    });
+
+    c.bench_function("common_random_usize_with_seed/2", |b| {
+        b.iter(|| ld::common::random_usize_with_seed(black_box(2), black_box(0x5eed_u64)))
     });
 }

--- a/benches/compact.rs
+++ b/benches/compact.rs
@@ -3,8 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_compact(c: &mut Criterion) {
-    let collection = support::defaulty_int_vec(4_096);
-    c.bench_function("compact", |b| {
-        b.iter(|| ld::compact(black_box(&collection)))
+    let defaulty = support::defaulty_int_vec(4_096);
+    c.bench_function("compact/defaulty_int_vec", |b| {
+        b.iter(|| ld::compact(black_box(&defaulty)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("compact/int_vec", |b| {
+        b.iter(|| ld::compact(black_box(&ints)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("compact/float_vec", |b| {
+        b.iter(|| ld::compact(black_box(&floats)))
     });
 }

--- a/benches/count.rs
+++ b/benches/count.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_count(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("count", |b| {
-        b.iter(|| ld::count(black_box(&collection), black_box(7)))
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("count/duplicate_int_vec/7", |b| {
+        b.iter(|| ld::count(black_box(&duplicates), black_box(7)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("count/int_vec/7", |b| {
+        b.iter(|| ld::count(black_box(&ints), black_box(7)))
     });
 }

--- a/benches/count_by.rs
+++ b/benches/count_by.rs
@@ -3,8 +3,23 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_count_by(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("count_by", |b| {
-        b.iter(|| ld::count_by(black_box(&collection), black_box(|value: &i32| *value > 0)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("count_by/int_vec", |b| {
+        b.iter(|| ld::count_by(black_box(&ints), black_box(|value: &i32| *value > 0)))
+    });
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("count_by/duplicate_int_vec", |b| {
+        b.iter(|| ld::count_by(black_box(&duplicates), black_box(|value: &i32| *value > 0)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("count_by/float_vec", |b| {
+        b.iter(|| ld::count_by(black_box(&floats), black_box(|value: &f64| *value > 0.0)))
+    });
+
+    let people = support::people(4_096);
+    c.bench_function("count_by/people", |b| {
+        b.iter(|| ld::count_by(black_box(&people), black_box(|p: &support::Person| p.age > 30)))
     });
 }

--- a/benches/count_values.rs
+++ b/benches/count_values.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_count_values(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("count_values", |b| {
-        b.iter(|| ld::count_values(black_box(&collection)))
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("count_values/duplicate_int_vec", |b| {
+        b.iter(|| ld::count_values(black_box(&duplicates)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("count_values/int_vec", |b| {
+        b.iter(|| ld::count_values(black_box(&ints)))
     });
 }

--- a/benches/count_values_by.rs
+++ b/benches/count_values_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_count_values_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("count_values_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("count_values_by/people/increasing", |b| {
         b.iter(|| {
             ld::count_values_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age / 10),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("count_values_by/people/equal", |b| {
+        b.iter(|| {
+            ld::count_values_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age / 10),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("count_values_by/int_vec", |b| {
+        b.iter(|| ld::count_values_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/drop.rs
+++ b/benches/drop.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_drop(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("drop", |b| {
-        b.iter(|| ld::drop(black_box(&collection), black_box(256)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("drop/int_vec/256", |b| {
+        b.iter(|| ld::drop(black_box(&ints), black_box(256)))
+    });
+
+    c.bench_function("drop/int_vec/4096", |b| {
+        b.iter(|| ld::drop(black_box(&ints), black_box(4096)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("drop/float_vec/256", |b| {
+        b.iter(|| ld::drop(black_box(&floats), black_box(256)))
     });
 }

--- a/benches/drop_by_index.rs
+++ b/benches/drop_by_index.rs
@@ -3,9 +3,20 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_drop_by_index(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
     let indexes = vec![1, 3, 5, 8, 13, 21, 34, 55, 89, 144];
-    c.bench_function("drop_by_index", |b| {
-        b.iter(|| ld::drop_by_index(black_box(&collection), black_box(&indexes)))
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("drop_by_index/int_vec", |b| {
+        b.iter(|| ld::drop_by_index(black_box(&ints), black_box(&indexes)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("drop_by_index/float_vec", |b| {
+        b.iter(|| ld::drop_by_index(black_box(&floats), black_box(&indexes)))
+    });
+
+    let more_indexes: Vec<isize> = (0..256).step_by(3).collect();
+    c.bench_function("drop_by_index/int_vec/256", |b| {
+        b.iter(|| ld::drop_by_index(black_box(&ints), black_box(&more_indexes)))
     });
 }

--- a/benches/drop_right.rs
+++ b/benches/drop_right.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_drop_right(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("drop_right", |b| {
-        b.iter(|| ld::drop_right(black_box(&collection), black_box(256)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("drop_right/int_vec/256", |b| {
+        b.iter(|| ld::drop_right(black_box(&ints), black_box(256)))
+    });
+
+    c.bench_function("drop_right/int_vec/4096", |b| {
+        b.iter(|| ld::drop_right(black_box(&ints), black_box(4096)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("drop_right/float_vec/256", |b| {
+        b.iter(|| ld::drop_right(black_box(&floats), black_box(256)))
     });
 }

--- a/benches/drop_right_while.rs
+++ b/benches/drop_right_while.rs
@@ -3,13 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_drop_right_while(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("drop_right_while", |b| {
-        b.iter(|| {
-            ld::drop_right_while(
-                black_box(&collection),
-                black_box(|value: &i32| *value > -10),
-            )
-        })
+    let ints = support::int_vec(4_096);
+    c.bench_function("drop_right_while/int_vec", |b| {
+        b.iter(|| ld::drop_right_while(black_box(&ints), black_box(|value: &i32| *value > -10)))
+    });
+
+    let descending = support::int_vec_descending(4_096);
+    c.bench_function("drop_right_while/descending", |b| {
+        b.iter(|| ld::drop_right_while(black_box(&descending), black_box(|value: &i32| *value > -10)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("drop_right_while/float_vec", |b| {
+        b.iter(|| ld::drop_right_while(black_box(&floats), black_box(|value: &f64| *value > -10.0)))
     });
 }

--- a/benches/drop_while.rs
+++ b/benches/drop_while.rs
@@ -3,8 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_drop_while(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("drop_while", |b| {
-        b.iter(|| ld::drop_while(black_box(&collection), black_box(|value: &i32| *value < 10)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("drop_while/int_vec", |b| {
+        b.iter(|| ld::drop_while(black_box(&ints), black_box(|value: &i32| *value < 10)))
+    });
+
+    let descending = support::int_vec_descending(4_096);
+    c.bench_function("drop_while/descending", |b| {
+        b.iter(|| ld::drop_while(black_box(&descending), black_box(|value: &i32| *value < 10)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("drop_while/float_vec", |b| {
+        b.iter(|| ld::drop_while(black_box(&floats), black_box(|value: &f64| *value < 10.0)))
     });
 }

--- a/benches/duration_between.rs
+++ b/benches/duration_between.rs
@@ -4,13 +4,15 @@ use lowdash as ld;
 pub fn benchmark_duration_between(c: &mut Criterion) {
     let start = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000);
     let end = start + std::time::Duration::from_secs(86_400 * 7);
-    c.bench_function("duration_between", |b| {
-        b.iter(|| {
-            ld::duration_between(
-                black_box(start),
-                black_box(end),
-                black_box(ld::DurationUnit::Days),
-            )
-        })
+    c.bench_function("duration_between/days", |b| {
+        b.iter(|| ld::duration_between(black_box(start), black_box(end), black_box(ld::DurationUnit::Days)))
+    });
+
+    c.bench_function("duration_between/hours", |b| {
+        b.iter(|| ld::duration_between(black_box(start), black_box(end), black_box(ld::DurationUnit::Hours)))
+    });
+
+    c.bench_function("duration_between/seconds", |b| {
+        b.iter(|| ld::duration_between(black_box(start), black_box(end), black_box(ld::DurationUnit::Seconds)))
     });
 }

--- a/benches/earliest.rs
+++ b/benches/earliest.rs
@@ -3,8 +3,23 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_earliest(c: &mut Criterion) {
-    let collection = support::time_vec(4_096);
-    c.bench_function("earliest", |b| {
-        b.iter(|| ld::earliest(black_box(&collection)))
+    let time_increasing = support::time_vec(4_096);
+    c.bench_function("earliest/time_vec/increasing", |b| {
+        b.iter(|| ld::earliest(black_box(&time_increasing)))
+    });
+
+    let time_descending = support::time_vec_descending(4_096);
+    c.bench_function("earliest/time_vec/descending", |b| {
+        b.iter(|| ld::earliest(black_box(&time_descending)))
+    });
+
+    let time_equal = support::time_vec_equal(4_096);
+    c.bench_function("earliest/time_vec/equal", |b| {
+        b.iter(|| ld::earliest(black_box(&time_equal)))
+    });
+
+    let time_shuffled = support::time_vec_shuffled(4_096);
+    c.bench_function("earliest/time_vec/shuffled", |b| {
+        b.iter(|| ld::earliest(black_box(&time_shuffled)))
     });
 }

--- a/benches/earliest_by.rs
+++ b/benches/earliest_by.rs
@@ -3,12 +3,82 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_earliest_by(c: &mut Criterion) {
-    let collection = support::timed_records(4_096);
-    c.bench_function("earliest_by", |b| {
+    let timed_records_increasing = support::timed_records(4_096);
+    c.bench_function("earliest_by/timed_records/increasing", |b| {
         b.iter(|| {
             ld::earliest_by(
-                black_box(&collection),
+                black_box(&timed_records_increasing),
                 black_box(|record: &support::TimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let timed_records_descending = support::timed_records_descending(4_096);
+    c.bench_function("earliest_by/timed_records/descending", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&timed_records_descending),
+                black_box(|record: &support::TimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let timed_records_equal = support::timed_records_equal(4_096);
+    c.bench_function("earliest_by/timed_records/equal", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&timed_records_equal),
+                black_box(|record: &support::TimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let timed_records_shuffled = support::timed_records_shuffled(4_096);
+    c.bench_function("earliest_by/timed_records/shuffled", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&timed_records_shuffled),
+                black_box(|record: &support::TimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let copy_records_increasing = support::copy_timed_records(4_096);
+    c.bench_function("earliest_by/copy_timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&copy_records_increasing),
+                black_box(|record: &support::CopyTimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let copy_records_descending = support::copy_timed_records_descending(4_096);
+    c.bench_function("earliest_by/copy_timed_records/descending", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&copy_records_descending),
+                black_box(|record: &support::CopyTimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let copy_records_equal = support::copy_timed_records_equal(4_096);
+    c.bench_function("earliest_by/copy_timed_records/equal", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&copy_records_equal),
+                black_box(|record: &support::CopyTimedRecord| record.timestamp),
+            )
+        })
+    });
+
+    let copy_records_shuffled = support::copy_timed_records_shuffled(4_096);
+    c.bench_function("earliest_by/copy_timed_records/shuffled", |b| {
+        b.iter(|| {
+            ld::earliest_by(
+                black_box(&copy_records_shuffled),
+                black_box(|record: &support::CopyTimedRecord| record.timestamp),
             )
         })
     });

--- a/benches/ellipsis.rs
+++ b/benches/ellipsis.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_ellipsis(c: &mut Criterion) {
-    let input = support::long_sentence();
-    c.bench_function("ellipsis", |b| {
-        b.iter(|| ld::ellipsis(black_box(input), black_box(48)))
+    let sentence = support::long_sentence();
+    c.bench_function("ellipsis/long_sentence/48", |b| {
+        b.iter(|| ld::ellipsis(black_box(sentence), black_box(48)))
+    });
+
+    c.bench_function("ellipsis/long_sentence/10", |b| {
+        b.iter(|| ld::ellipsis(black_box(sentence), black_box(10)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("ellipsis/short/3", |b| {
+        b.iter(|| ld::ellipsis(black_box(short), black_box(3)))
     });
 }

--- a/benches/entries.rs
+++ b/benches/entries.rs
@@ -4,5 +4,8 @@ use lowdash as ld;
 
 pub fn benchmark_entries(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("entries", |b| b.iter(|| ld::entries(black_box(&map))));
+    c.bench_function("entries/medium", |b| b.iter(|| ld::entries(black_box(&map))));
+
+    let small = support::numeric_map(64);
+    c.bench_function("entries/small", |b| b.iter(|| ld::entries(black_box(&small))));
 }

--- a/benches/fill.rs
+++ b/benches/fill.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_fill(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("fill", |b| {
-        b.iter(|| ld::fill(black_box(&collection), black_box(7)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("fill/int_vec/7", |b| {
+        b.iter(|| ld::fill(black_box(&ints), black_box(7)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("fill/float_vec/3.14", |b| {
+        b.iter(|| ld::fill(black_box(&floats), black_box(3.14)))
     });
 }

--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -3,13 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_filter(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("filter", |b| {
-        b.iter(|| {
-            ld::filter(
-                black_box(&collection),
-                black_box(|value: &i32, _| *value % 2 == 0),
-            )
-        })
+    let ints = support::int_vec(4_096);
+    c.bench_function("filter/int_vec", |b| {
+        b.iter(|| ld::filter(black_box(&ints), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("filter/duplicate_int_vec", |b| {
+        b.iter(|| ld::filter(black_box(&duplicates), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("filter/float_vec", |b| {
+        b.iter(|| ld::filter(black_box(&floats), black_box(|value: &f64, _| *value > 0.0)))
     });
 }

--- a/benches/filter_map.rs
+++ b/benches/filter_map.rs
@@ -3,12 +3,22 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_filter_map(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("filter_map", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("filter_map/int_vec", |b| {
         b.iter(|| {
             ld::filter_map(
-                black_box(&collection),
+                black_box(&ints),
                 black_box(|value: &i32, index| (*value + index as i32, index % 2 == 0)),
+            )
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("filter_map/float_vec", |b| {
+        b.iter(|| {
+            ld::filter_map(
+                black_box(&floats),
+                black_box(|value: &f64, index| (*value + index as f64, index % 2 == 0)),
             )
         })
     });

--- a/benches/filter_reject.rs
+++ b/benches/filter_reject.rs
@@ -3,13 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_filter_reject(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("filter_reject", |b| {
-        b.iter(|| {
-            ld::filter_reject(
-                black_box(&collection),
-                black_box(|value: &i32, _| *value % 2 == 0),
-            )
-        })
+    let ints = support::int_vec(4_096);
+    c.bench_function("filter_reject/int_vec", |b| {
+        b.iter(|| ld::filter_reject(black_box(&ints), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("filter_reject/duplicate_int_vec", |b| {
+        b.iter(|| ld::filter_reject(black_box(&duplicates), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("filter_reject/float_vec", |b| {
+        b.iter(|| ld::filter_reject(black_box(&floats), black_box(|value: &f64, _| *value > 0.0)))
     });
 }

--- a/benches/find.rs
+++ b/benches/find.rs
@@ -1,14 +1,19 @@
+use crate::support;
 use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("find", |b| {
-        b.iter(|| {
-            ld::find(
-                black_box(&collection),
-                black_box(|value: &i32| *value == 4_095),
-            )
-        })
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("find/int_vec/exists", |b| {
+        b.iter(|| ld::find(black_box(&ints), black_box(|value: &i32| *value == 4_095)))
+    });
+
+    c.bench_function("find/int_vec/missing", |b| {
+        b.iter(|| ld::find(black_box(&ints), black_box(|value: &i32| *value == -1)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("find/float_vec", |b| {
+        b.iter(|| ld::find(black_box(&floats), black_box(|value: &f64| *value > 10.0)))
     });
 }

--- a/benches/find_duplicates.rs
+++ b/benches/find_duplicates.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_duplicates(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("find_duplicates", |b| {
-        b.iter(|| ld::find_duplicates(black_box(&collection)))
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("find_duplicates/duplicate_int_vec", |b| {
+        b.iter(|| ld::find_duplicates(black_box(&duplicates)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("find_duplicates/int_vec", |b| {
+        b.iter(|| ld::find_duplicates(black_box(&ints)))
     });
 }

--- a/benches/find_duplicates_by.rs
+++ b/benches/find_duplicates_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_duplicates_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("find_duplicates_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("find_duplicates_by/people/increasing", |b| {
         b.iter(|| {
             ld::find_duplicates_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("find_duplicates_by/people/equal", |b| {
+        b.iter(|| {
+            ld::find_duplicates_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("find_duplicates_by/int_vec", |b| {
+        b.iter(|| ld::find_duplicates_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/find_index_of.rs
+++ b/benches/find_index_of.rs
@@ -1,14 +1,19 @@
+use crate::support;
 use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_index_of(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("find_index_of", |b| {
-        b.iter(|| {
-            ld::find_index_of(
-                black_box(&collection),
-                black_box(|value: &i32| *value == 4_095),
-            )
-        })
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("find_index_of/int_vec/exists", |b| {
+        b.iter(|| ld::find_index_of(black_box(&ints), black_box(|value: &i32| *value == 4_095)))
+    });
+
+    c.bench_function("find_index_of/int_vec/missing", |b| {
+        b.iter(|| ld::find_index_of(black_box(&ints), black_box(|value: &i32| *value == -1)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("find_index_of/float_vec", |b| {
+        b.iter(|| ld::find_index_of(black_box(&floats), black_box(|value: &f64| *value > 10.0)))
     });
 }

--- a/benches/find_key.rs
+++ b/benches/find_key.rs
@@ -4,7 +4,11 @@ use lowdash as ld;
 
 pub fn benchmark_find_key(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("find_key", |b| {
+    c.bench_function("find_key/map/exists", |b| {
         b.iter(|| ld::find_key(black_box(&map), black_box(13)))
+    });
+
+    c.bench_function("find_key/map/missing", |b| {
+        b.iter(|| ld::find_key(black_box(&map), black_box(999)))
     });
 }

--- a/benches/find_key_by.rs
+++ b/benches/find_key_by.rs
@@ -4,10 +4,20 @@ use lowdash as ld;
 
 pub fn benchmark_find_key_by(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("find_key_by", |b| {
+    c.bench_function("find_key_by/map", |b| {
         b.iter(|| {
             ld::find_key_by(
                 black_box(&map),
+                black_box(|key: &String, value: &i32| key.ends_with('7') && *value >= 0),
+            )
+        })
+    });
+
+    let map_large = support::numeric_map(8_192);
+    c.bench_function("find_key_by/large", |b| {
+        b.iter(|| {
+            ld::find_key_by(
+                black_box(&map_large),
                 black_box(|key: &String, value: &i32| key.ends_with('7') && *value >= 0),
             )
         })

--- a/benches/find_last_index_of.rs
+++ b/benches/find_last_index_of.rs
@@ -2,13 +2,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_last_index_of(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("find_last_index_of", |b| {
-        b.iter(|| {
-            ld::find_last_index_of(
-                black_box(&collection),
-                black_box(|value: &i32| *value == 4_095),
-            )
-        })
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("find_last_index_of/int_vec/exists", |b| {
+        b.iter(|| ld::find_last_index_of(black_box(&ints), black_box(|value: &i32| *value == 4_095)))
+    });
+
+    c.bench_function("find_last_index_of/int_vec/missing", |b| {
+        b.iter(|| ld::find_last_index_of(black_box(&ints), black_box(|value: &i32| *value == -1)))
     });
 }

--- a/benches/find_or_else.rs
+++ b/benches/find_or_else.rs
@@ -2,14 +2,22 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_or_else(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
     let fallback = -1;
-    c.bench_function("find_or_else", |b| {
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("find_or_else/int_vec/exists", |b| {
         b.iter(|| {
             ld::find_or_else(
-                black_box(&collection),
-                black_box(&fallback),
+                black_box(&ints), black_box(&fallback),
                 black_box(|value: &i32| *value == 4_095),
+            )
+        })
+    });
+
+    c.bench_function("find_or_else/int_vec/missing", |b| {
+        b.iter(|| {
+            ld::find_or_else(
+                black_box(&ints), black_box(&fallback),
+                black_box(|value: &i32| *value == -1),
             )
         })
     });

--- a/benches/find_uniques.rs
+++ b/benches/find_uniques.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_uniques(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("find_uniques", |b| {
-        b.iter(|| ld::find_uniques(black_box(&collection)))
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("find_uniques/duplicate_int_vec", |b| {
+        b.iter(|| ld::find_uniques(black_box(&duplicates)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("find_uniques/int_vec", |b| {
+        b.iter(|| ld::find_uniques(black_box(&ints)))
     });
 }

--- a/benches/find_uniques_by.rs
+++ b/benches/find_uniques_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_find_uniques_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("find_uniques_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("find_uniques_by/people/increasing", |b| {
         b.iter(|| {
             ld::find_uniques_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("find_uniques_by/people/equal", |b| {
+        b.iter(|| {
+            ld::find_uniques_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("find_uniques_by/int_vec", |b| {
+        b.iter(|| ld::find_uniques_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/first.rs
+++ b/benches/first.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_first(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("first", |b| b.iter(|| ld::first(black_box(&collection))));
+    let ints = support::int_vec(4_096);
+    c.bench_function("first/int_vec", |b| b.iter(|| ld::first(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("first/float_vec", |b| b.iter(|| ld::first(black_box(&floats))));
 }

--- a/benches/first_or.rs
+++ b/benches/first_or.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_first_or(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("first_or", |b| {
-        b.iter(|| ld::first_or(black_box(&collection), black_box(-1)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("first_or/int_vec", |b| {
+        b.iter(|| ld::first_or(black_box(&ints), black_box(-1)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("first_or/float_vec", |b| {
+        b.iter(|| ld::first_or(black_box(&floats), black_box(-1.0)))
     });
 }

--- a/benches/first_or_empty.rs
+++ b/benches/first_or_empty.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_first_or_empty(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("first_or_empty", |b| {
-        b.iter(|| ld::first_or_empty(black_box(&collection)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("first_or_empty/int_vec", |b| {
+        b.iter(|| ld::first_or_empty(black_box(&ints)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("first_or_empty/float_vec", |b| {
+        b.iter(|| ld::first_or_empty(black_box(&floats)))
     });
 }

--- a/benches/flat_map.rs
+++ b/benches/flat_map.rs
@@ -3,12 +3,22 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_flat_map(c: &mut Criterion) {
-    let collection = support::int_vec(2_048);
-    c.bench_function("flat_map", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("flat_map/int_vec", |b| {
         b.iter(|| {
             ld::flat_map(
-                black_box(&collection),
+                black_box(&ints),
                 black_box(|value: &i32, _| vec![*value, *value * 2]),
+            )
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("flat_map/float_vec", |b| {
+        b.iter(|| {
+            ld::flat_map(
+                black_box(&floats),
+                black_box(|value: &f64, _| vec![*value, *value * 2.0]),
             )
         })
     });

--- a/benches/flatten.rs
+++ b/benches/flatten.rs
@@ -3,8 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_flatten(c: &mut Criterion) {
-    let collection = support::nested_vecs(128, 8);
-    c.bench_function("flatten", |b| {
-        b.iter(|| ld::flatten(black_box(&collection)))
+    let nested = support::nested_vecs(128, 32);
+    c.bench_function("flatten/nested/128x32", |b| {
+        b.iter(|| ld::flatten(black_box(&nested)))
+    });
+
+    let small = support::nested_vecs(32, 8);
+    c.bench_function("flatten/nested/32x8", |b| {
+        b.iter(|| ld::flatten(black_box(&small)))
+    });
+
+    let ragged = support::ragged_vecs();
+    c.bench_function("flatten/ragged", |b| {
+        b.iter(|| ld::flatten(black_box(&ragged)))
     });
 }

--- a/benches/foreach.rs
+++ b/benches/foreach.rs
@@ -3,13 +3,20 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_foreach(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("foreach", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("foreach/int_vec", |b| {
         b.iter(|| {
             let mut total = 0_i64;
-            ld::foreach(black_box(&collection), |value: &i32, _| {
-                total += *value as i64
-            });
+            ld::foreach(black_box(&ints), |value: &i32, _| total += *value as i64);
+            black_box(total)
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("foreach/float_vec", |b| {
+        b.iter(|| {
+            let mut total = 0.0_f64;
+            ld::foreach(black_box(&floats), |value: &f64, _| total += *value);
             black_box(total)
         })
     });

--- a/benches/foreach_while.rs
+++ b/benches/foreach_while.rs
@@ -3,13 +3,25 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_foreach_while(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("foreach_while", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("foreach_while/int_vec", |b| {
         b.iter(|| {
             let mut total = 0_i64;
-            ld::foreach_while(black_box(&collection), |value: &i32, _| {
+            ld::foreach_while(black_box(&ints), |value: &i32, _| {
                 total += *value as i64;
                 total < 10_000
+            });
+            black_box(total)
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("foreach_while/float_vec", |b| {
+        b.iter(|| {
+            let mut total = 0.0_f64;
+            ld::foreach_while(black_box(&floats), |value: &f64, _| {
+                total += *value;
+                total < 100.0
             });
             black_box(total)
         })

--- a/benches/from_entries.rs
+++ b/benches/from_entries.rs
@@ -4,7 +4,8 @@ use lowdash as ld;
 
 pub fn benchmark_from_entries(c: &mut Criterion) {
     let entries = support::entry_vec(2_048);
-    c.bench_function("from_entries", |b| {
-        b.iter(|| ld::from_entries(black_box(&entries)))
-    });
+    c.bench_function("from_entries/medium", |b| b.iter(|| ld::from_entries(black_box(&entries))));
+
+    let small = support::entry_vec(64);
+    c.bench_function("from_entries/small", |b| b.iter(|| ld::from_entries(black_box(&small))));
 }

--- a/benches/from_pairs.rs
+++ b/benches/from_pairs.rs
@@ -4,7 +4,8 @@ use lowdash as ld;
 
 pub fn benchmark_from_pairs(c: &mut Criterion) {
     let entries = support::entry_vec(2_048);
-    c.bench_function("from_pairs", |b| {
-        b.iter(|| ld::from_pairs(black_box(&entries)))
-    });
+    c.bench_function("from_pairs/medium", |b| b.iter(|| ld::from_pairs(black_box(&entries))));
+
+    let small = support::entry_vec(64);
+    c.bench_function("from_pairs/small", |b| b.iter(|| ld::from_pairs(black_box(&small))));
 }

--- a/benches/group_by.rs
+++ b/benches/group_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_group_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("group_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("group_by/people/increasing", |b| {
         b.iter(|| {
             ld::group_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age / 10),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("group_by/people/equal", |b| {
+        b.iter(|| {
+            ld::group_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age / 10),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("group_by/int_vec", |b| {
+        b.iter(|| ld::group_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/has_key.rs
+++ b/benches/has_key.rs
@@ -4,8 +4,13 @@ use lowdash as ld;
 
 pub fn benchmark_has_key(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    let key = String::from("key-1024");
-    c.bench_function("has_key", |b| {
-        b.iter(|| ld::has_key(black_box(&map), black_box(&key)))
+    let existing = String::from("key-1024");
+    c.bench_function("has_key/map/exists", |b| {
+        b.iter(|| ld::has_key(black_box(&map), black_box(&existing)))
+    });
+
+    let missing = String::from("missing");
+    c.bench_function("has_key/map/missing", |b| {
+        b.iter(|| ld::has_key(black_box(&map), black_box(&missing)))
     });
 }

--- a/benches/index_of.rs
+++ b/benches/index_of.rs
@@ -2,8 +2,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_index_of(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("index_of", |b| {
-        b.iter(|| ld::index_of(black_box(&collection), black_box(4_095)))
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("index_of/int_vec/exists", |b| {
+        b.iter(|| ld::index_of(black_box(&ints), black_box(4_095)))
+    });
+
+    c.bench_function("index_of/int_vec/missing", |b| {
+        b.iter(|| ld::index_of(black_box(&ints), black_box(-1)))
     });
 }

--- a/benches/interleave.rs
+++ b/benches/interleave.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_interleave(c: &mut Criterion) {
-    let collection = support::ragged_vecs();
-    c.bench_function("interleave", |b| {
-        b.iter(|| ld::interleave(black_box(&collection)))
+    let ragged = support::ragged_vecs();
+    c.bench_function("interleave/ragged", |b| {
+        b.iter(|| ld::interleave(black_box(&ragged)))
+    });
+
+    let regular = support::nested_vecs(16, 16);
+    c.bench_function("interleave/regular/16x16", |b| {
+        b.iter(|| ld::interleave(black_box(&regular)))
     });
 }

--- a/benches/interpolate.rs
+++ b/benches/interpolate.rs
@@ -2,10 +2,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_interpolate(c: &mut Criterion) {
-    c.bench_function("interpolate", |b| {
+    c.bench_function("interpolate/10-90-0.42", |b| {
         b.iter(|| {
             let f = ld::interpolate(black_box(10.0), black_box(90.0));
             f(black_box(0.42))
+        })
+    });
+
+    c.bench_function("interpolate/0-100-0.5", |b| {
+        b.iter(|| {
+            let f = ld::interpolate(black_box(0.0), black_box(100.0));
+            f(black_box(0.5))
         })
     });
 }

--- a/benches/invert.rs
+++ b/benches/invert.rs
@@ -4,5 +4,8 @@ use lowdash as ld;
 
 pub fn benchmark_invert(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("invert", |b| b.iter(|| ld::invert(black_box(&map))));
+    c.bench_function("invert/medium", |b| b.iter(|| ld::invert(black_box(&map))));
+
+    let small = support::numeric_map(64);
+    c.bench_function("invert/small", |b| b.iter(|| ld::invert(black_box(&small))));
 }

--- a/benches/is_sorted.rs
+++ b/benches/is_sorted.rs
@@ -1,9 +1,14 @@
+use crate::support;
 use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_is_sorted(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("is_sorted", |b| {
-        b.iter(|| ld::is_sorted(black_box(&collection)))
-    });
+    let increasing: Vec<i32> = (0..4_096).collect();
+    c.bench_function("is_sorted/increasing", |b| b.iter(|| ld::is_sorted(black_box(&increasing))));
+
+    let descending = support::int_vec_descending(4_096);
+    c.bench_function("is_sorted/descending", |b| b.iter(|| ld::is_sorted(black_box(&descending))));
+
+    let shuffled = support::int_vec_shuffled(4_096);
+    c.bench_function("is_sorted/shuffled", |b| b.iter(|| ld::is_sorted(black_box(&shuffled))));
 }

--- a/benches/is_sorted_by_key.rs
+++ b/benches/is_sorted_by_key.rs
@@ -3,19 +3,20 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_is_sorted_by_key(c: &mut Criterion) {
-    let collection: Vec<support::Person> = (0..512)
-        .map(|i| support::Person {
-            id: i,
-            name: format!("person-{i}"),
-            age: i as u32,
-        })
+    let increasing: Vec<support::Person> = (0..4_096)
+        .map(|i| support::Person { id: i, name: format!("person-{i}"), age: i as u32 })
         .collect();
-    c.bench_function("is_sorted_by_key", |b| {
-        b.iter(|| {
-            ld::is_sorted_by_key(
-                black_box(&collection),
-                black_box(|person: &support::Person| person.age),
-            )
-        })
+    c.bench_function("is_sorted_by_key/increasing", |b| {
+        b.iter(|| ld::is_sorted_by_key(black_box(&increasing), black_box(|p: &support::Person| p.age)))
+    });
+
+    let descending = support::people_descending(4_096);
+    c.bench_function("is_sorted_by_key/descending", |b| {
+        b.iter(|| ld::is_sorted_by_key(black_box(&descending), black_box(|p: &support::Person| p.age)))
+    });
+
+    let same = support::people_same_age(4_096);
+    c.bench_function("is_sorted_by_key/equal", |b| {
+        b.iter(|| ld::is_sorted_by_key(black_box(&same), black_box(|p: &support::Person| p.age)))
     });
 }

--- a/benches/kebab_case.rs
+++ b/benches/kebab_case.rs
@@ -4,7 +4,17 @@ use lowdash as ld;
 
 pub fn benchmark_kebab_case(c: &mut Criterion) {
     let input = support::mixed_identifier();
-    c.bench_function("kebab_case", |b| {
+    c.bench_function("kebab_case/mixed_identifier", |b| {
         b.iter(|| ld::kebab_case(black_box(input)))
+    });
+
+    let sentence = support::long_sentence();
+    c.bench_function("kebab_case/long_sentence", |b| {
+        b.iter(|| ld::kebab_case(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("kebab_case/short", |b| {
+        b.iter(|| ld::kebab_case(black_box(short)))
     });
 }

--- a/benches/key_by.rs
+++ b/benches/key_by.rs
@@ -3,12 +3,32 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_key_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("key_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("key_by/people/increasing", |b| {
         b.iter(|| {
             ld::key_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.name.clone()),
+            )
+        })
+    });
+
+    let people_shuffled = support::people_shuffled(4_096);
+    c.bench_function("key_by/people/shuffled", |b| {
+        b.iter(|| {
+            ld::key_by(
+                black_box(&people_shuffled),
+                black_box(|person: &support::Person| person.name.clone()),
+            )
+        })
+    });
+
+    let timed_records = support::timed_records(4_096);
+    c.bench_function("key_by/timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::key_by(
+                black_box(&timed_records),
+                black_box(|record: &support::TimedRecord| record.name.clone()),
             )
         })
     });

--- a/benches/keys.rs
+++ b/benches/keys.rs
@@ -5,5 +5,9 @@ use lowdash as ld;
 pub fn benchmark_keys(c: &mut Criterion) {
     let maps = support::numeric_maps(8, 256);
     let refs = support::map_refs(&maps);
-    c.bench_function("keys", |b| b.iter(|| ld::keys(black_box(&refs))));
+    c.bench_function("keys/medium", |b| b.iter(|| ld::keys(black_box(&refs))));
+
+    let small_maps = support::numeric_maps(4, 32);
+    let small_refs = support::map_refs(&small_maps);
+    c.bench_function("keys/small", |b| b.iter(|| ld::keys(black_box(&small_refs))));
 }

--- a/benches/last.rs
+++ b/benches/last.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_last(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("last", |b| b.iter(|| ld::last(black_box(&collection))));
+    let ints = support::int_vec(4_096);
+    c.bench_function("last/int_vec", |b| b.iter(|| ld::last(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("last/float_vec", |b| b.iter(|| ld::last(black_box(&floats))));
 }

--- a/benches/last_index_of.rs
+++ b/benches/last_index_of.rs
@@ -2,8 +2,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_last_index_of(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("last_index_of", |b| {
-        b.iter(|| ld::last_index_of(black_box(&collection), black_box(4_095)))
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("last_index_of/int_vec/exists", |b| {
+        b.iter(|| ld::last_index_of(black_box(&ints), black_box(4_095)))
+    });
+
+    c.bench_function("last_index_of/int_vec/missing", |b| {
+        b.iter(|| ld::last_index_of(black_box(&ints), black_box(-1)))
     });
 }

--- a/benches/last_or.rs
+++ b/benches/last_or.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_last_or(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("last_or", |b| {
-        b.iter(|| ld::last_or(black_box(&collection), black_box(-1)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("last_or/int_vec", |b| {
+        b.iter(|| ld::last_or(black_box(&ints), black_box(-1)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("last_or/float_vec", |b| {
+        b.iter(|| ld::last_or(black_box(&floats), black_box(-1.0)))
     });
 }

--- a/benches/last_or_empty.rs
+++ b/benches/last_or_empty.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_last_or_empty(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("last_or_empty", |b| {
-        b.iter(|| ld::last_or_empty(black_box(&collection)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("last_or_empty/int_vec", |b| {
+        b.iter(|| ld::last_or_empty(black_box(&ints)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("last_or_empty/float_vec", |b| {
+        b.iter(|| ld::last_or_empty(black_box(&floats)))
     });
 }

--- a/benches/latest.rs
+++ b/benches/latest.rs
@@ -3,6 +3,23 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_latest(c: &mut Criterion) {
-    let collection = support::time_vec(4_096);
-    c.bench_function("latest", |b| b.iter(|| ld::latest(black_box(&collection))));
+    let time_increasing = support::time_vec(4_096);
+    c.bench_function("latest/time_vec/increasing", |b| {
+        b.iter(|| ld::latest(black_box(&time_increasing)))
+    });
+
+    let time_descending = support::time_vec_descending(4_096);
+    c.bench_function("latest/time_vec/descending", |b| {
+        b.iter(|| ld::latest(black_box(&time_descending)))
+    });
+
+    let time_equal = support::time_vec_equal(4_096);
+    c.bench_function("latest/time_vec/equal", |b| {
+        b.iter(|| ld::latest(black_box(&time_equal)))
+    });
+
+    let time_shuffled = support::time_vec_shuffled(4_096);
+    c.bench_function("latest/time_vec/shuffled", |b| {
+        b.iter(|| ld::latest(black_box(&time_shuffled)))
+    });
 }

--- a/benches/map.rs
+++ b/benches/map.rs
@@ -3,13 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_map(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("map", |b| {
-        b.iter(|| {
-            ld::map(
-                black_box(&collection),
-                black_box(|value: &i32, _| *value * 2),
-            )
-        })
+    let ints = support::int_vec(4_096);
+    c.bench_function("map/int_vec", |b| {
+        b.iter(|| ld::map(black_box(&ints), black_box(|value: &i32, _| *value * 2)))
+    });
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("map/duplicate_int_vec", |b| {
+        b.iter(|| ld::map(black_box(&duplicates), black_box(|value: &i32, _| *value * 2)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("map/float_vec", |b| {
+        b.iter(|| ld::map(black_box(&floats), black_box(|value: &f64, _| *value * 2.0)))
     });
 }

--- a/benches/map_entries.rs
+++ b/benches/map_entries.rs
@@ -4,10 +4,20 @@ use lowdash as ld;
 
 pub fn benchmark_map_entries(c: &mut Criterion) {
     let map = support::numeric_map(1_024);
-    c.bench_function("map_entries", |b| {
+    c.bench_function("map_entries/medium", |b| {
         b.iter(|| {
             ld::map_entries(
                 black_box(&map),
+                black_box(|key: &String, value: &i32| (format!("mapped-{key}"), *value * 2)),
+            )
+        })
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("map_entries/small", |b| {
+        b.iter(|| {
+            ld::map_entries(
+                black_box(&small),
                 black_box(|key: &String, value: &i32| (format!("mapped-{key}"), *value * 2)),
             )
         })

--- a/benches/map_keys.rs
+++ b/benches/map_keys.rs
@@ -4,10 +4,20 @@ use lowdash as ld;
 
 pub fn benchmark_map_keys(c: &mut Criterion) {
     let map = support::numeric_map(1_024);
-    c.bench_function("map_keys", |b| {
+    c.bench_function("map_keys/medium", |b| {
         b.iter(|| {
             ld::map_keys(
                 black_box(&map),
+                black_box(|value: &i32, key: &String| format!("{key}-{}", value.abs())),
+            )
+        })
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("map_keys/small", |b| {
+        b.iter(|| {
+            ld::map_keys(
+                black_box(&small),
                 black_box(|value: &i32, key: &String| format!("{key}-{}", value.abs())),
             )
         })

--- a/benches/map_to_slice.rs
+++ b/benches/map_to_slice.rs
@@ -4,10 +4,20 @@ use lowdash as ld;
 
 pub fn benchmark_map_to_slice(c: &mut Criterion) {
     let map = support::numeric_map(1_024);
-    c.bench_function("map_to_slice", |b| {
+    c.bench_function("map_to_slice/medium", |b| {
         b.iter(|| {
             ld::map_to_slice(
                 black_box(&map),
+                black_box(|key: &String, value: &i32| format!("{key}:{value}")),
+            )
+        })
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("map_to_slice/small", |b| {
+        b.iter(|| {
+            ld::map_to_slice(
+                black_box(&small),
                 black_box(|key: &String, value: &i32| format!("{key}:{value}")),
             )
         })

--- a/benches/map_values.rs
+++ b/benches/map_values.rs
@@ -4,10 +4,20 @@ use lowdash as ld;
 
 pub fn benchmark_map_values(c: &mut Criterion) {
     let map = support::numeric_map(1_024);
-    c.bench_function("map_values", |b| {
+    c.bench_function("map_values/medium", |b| {
         b.iter(|| {
             ld::map_values(
                 black_box(&map),
+                black_box(|value: &i32, key: &String| format!("{key}:{value}")),
+            )
+        })
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("map_values/small", |b| {
+        b.iter(|| {
+            ld::map_values(
+                black_box(&small),
                 black_box(|value: &i32, key: &String| format!("{key}:{value}")),
             )
         })

--- a/benches/max.rs
+++ b/benches/max.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_max(c: &mut Criterion) {
-    let collection = support::float_vec(4_096);
-    c.bench_function("max", |b| b.iter(|| ld::max(black_box(&collection))));
+    let floats = support::float_vec(4_096);
+    c.bench_function("max/float_vec", |b| b.iter(|| ld::max(black_box(&floats))));
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("max/int_vec", |b| b.iter(|| ld::max(black_box(&ints))));
 }

--- a/benches/max_by.rs
+++ b/benches/max_by.rs
@@ -3,12 +3,62 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_max_by(c: &mut Criterion) {
-    let collection = support::people(4_096);
-    c.bench_function("max_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("max_by/people/increasing", |b| {
         b.iter(|| {
             ld::max_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|a: &support::Person, b: &support::Person| a.age > b.age),
+            )
+        })
+    });
+
+    let people_desc = support::people_descending(4_096);
+    c.bench_function("max_by/people/descending", |b| {
+        b.iter(|| {
+            ld::max_by(
+                black_box(&people_desc),
+                black_box(|a: &support::Person, b: &support::Person| a.age > b.age),
+            )
+        })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("max_by/people/equal", |b| {
+        b.iter(|| {
+            ld::max_by(
+                black_box(&people_same),
+                black_box(|a: &support::Person, b: &support::Person| a.age > b.age),
+            )
+        })
+    });
+
+    let people_shuffled = support::people_shuffled(4_096);
+    c.bench_function("max_by/people/shuffled", |b| {
+        b.iter(|| {
+            ld::max_by(
+                black_box(&people_shuffled),
+                black_box(|a: &support::Person, b: &support::Person| a.age > b.age),
+            )
+        })
+    });
+
+    let timed_records = support::timed_records(4_096);
+    c.bench_function("max_by/timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::max_by(
+                black_box(&timed_records),
+                black_box(|a: &support::TimedRecord, b: &support::TimedRecord| a.timestamp > b.timestamp),
+            )
+        })
+    });
+
+    let copy_timed_records = support::copy_timed_records(4_096);
+    c.bench_function("max_by/copy_timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::max_by(
+                black_box(&copy_timed_records),
+                black_box(|a: &support::CopyTimedRecord, b: &support::CopyTimedRecord| a.timestamp > b.timestamp),
             )
         })
     });

--- a/benches/mean.rs
+++ b/benches/mean.rs
@@ -3,6 +3,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_mean(c: &mut Criterion) {
-    let collection = support::float_vec(128);
-    c.bench_function("mean", |b| b.iter(|| ld::mean(black_box(&collection))));
+    let floats = support::float_vec(4_096);
+    c.bench_function("mean/float_vec/large", |b| b.iter(|| ld::mean(black_box(&floats))));
+
+    let small = support::float_vec(128);
+    c.bench_function("mean/float_vec/small", |b| b.iter(|| ld::mean(black_box(&small))));
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("mean/int_vec", |b| b.iter(|| ld::mean(black_box(&ints))));
 }

--- a/benches/mean_by.rs
+++ b/benches/mean_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_mean_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("mean_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("mean_by/people/increasing", |b| {
         b.iter(|| {
             ld::mean_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age as f64),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("mean_by/people/equal", |b| {
+        b.iter(|| {
+            ld::mean_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age as f64),
+            )
+        })
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("mean_by/int_vec", |b| {
+        b.iter(|| ld::mean_by(black_box(&ints), black_box(|x: &i32| *x as f64)))
     });
 }

--- a/benches/median.rs
+++ b/benches/median.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_median(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("median", |b| b.iter(|| ld::median(black_box(&collection))));
+    let ints = support::int_vec(4_096);
+    c.bench_function("median/int_vec", |b| b.iter(|| ld::median(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("median/float_vec", |b| b.iter(|| ld::median(black_box(&floats))));
 }

--- a/benches/min.rs
+++ b/benches/min.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_min(c: &mut Criterion) {
-    let collection = support::float_vec(4_096);
-    c.bench_function("min", |b| b.iter(|| ld::min(black_box(&collection))));
+    let floats = support::float_vec(4_096);
+    c.bench_function("min/float_vec", |b| b.iter(|| ld::min(black_box(&floats))));
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("min/int_vec", |b| b.iter(|| ld::min(black_box(&ints))));
 }

--- a/benches/min_by.rs
+++ b/benches/min_by.rs
@@ -3,12 +3,62 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_min_by(c: &mut Criterion) {
-    let collection = support::people(4_096);
-    c.bench_function("min_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("min_by/people/increasing", |b| {
         b.iter(|| {
             ld::min_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|a: &support::Person, b: &support::Person| a.age < b.age),
+            )
+        })
+    });
+
+    let people_desc = support::people_descending(4_096);
+    c.bench_function("min_by/people/descending", |b| {
+        b.iter(|| {
+            ld::min_by(
+                black_box(&people_desc),
+                black_box(|a: &support::Person, b: &support::Person| a.age < b.age),
+            )
+        })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("min_by/people/equal", |b| {
+        b.iter(|| {
+            ld::min_by(
+                black_box(&people_same),
+                black_box(|a: &support::Person, b: &support::Person| a.age < b.age),
+            )
+        })
+    });
+
+    let people_shuffled = support::people_shuffled(4_096);
+    c.bench_function("min_by/people/shuffled", |b| {
+        b.iter(|| {
+            ld::min_by(
+                black_box(&people_shuffled),
+                black_box(|a: &support::Person, b: &support::Person| a.age < b.age),
+            )
+        })
+    });
+
+    let timed_records = support::timed_records(4_096);
+    c.bench_function("min_by/timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::min_by(
+                black_box(&timed_records),
+                black_box(|a: &support::TimedRecord, b: &support::TimedRecord| a.timestamp < b.timestamp),
+            )
+        })
+    });
+
+    let copy_timed_records = support::copy_timed_records(4_096);
+    c.bench_function("min_by/copy_timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::min_by(
+                black_box(&copy_timed_records),
+                black_box(|a: &support::CopyTimedRecord, b: &support::CopyTimedRecord| a.timestamp < b.timestamp),
             )
         })
     });

--- a/benches/nearest_power_of_two.rs
+++ b/benches/nearest_power_of_two.rs
@@ -2,7 +2,15 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_nearest_power_of_two(c: &mut Criterion) {
-    c.bench_function("nearest_power_of_two", |b| {
+    c.bench_function("nearest_power_of_two/65537", |b| {
         b.iter(|| ld::nearest_power_of_two(black_box(65_537)))
+    });
+
+    c.bench_function("nearest_power_of_two/1", |b| {
+        b.iter(|| ld::nearest_power_of_two(black_box(1)))
+    });
+
+    c.bench_function("nearest_power_of_two/1000", |b| {
+        b.iter(|| ld::nearest_power_of_two(black_box(1000)))
     });
 }

--- a/benches/nth.rs
+++ b/benches/nth.rs
@@ -2,8 +2,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_nth(c: &mut Criterion) {
-    let collection: Vec<i32> = (0..4_096).collect();
-    c.bench_function("nth", |b| {
-        b.iter(|| ld::nth(black_box(&collection), black_box(-10)))
+    let ints: Vec<i32> = (0..4_096).collect();
+    c.bench_function("nth/int_vec/neg", |b| {
+        b.iter(|| ld::nth(black_box(&ints), black_box(-10)))
+    });
+
+    c.bench_function("nth/int_vec/pos", |b| {
+        b.iter(|| ld::nth(black_box(&ints), black_box(100)))
     });
 }

--- a/benches/omit_by.rs
+++ b/benches/omit_by.rs
@@ -4,12 +4,12 @@ use lowdash as ld;
 
 pub fn benchmark_omit_by(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("omit_by", |b| {
-        b.iter(|| {
-            ld::omit_by(
-                black_box(&map),
-                black_box(|_: &String, value: &i32| *value > 0),
-            )
-        })
+    c.bench_function("omit_by/medium", |b| {
+        b.iter(|| ld::omit_by(black_box(&map), black_box(|_: &String, value: &i32| *value > 0)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("omit_by/small", |b| {
+        b.iter(|| ld::omit_by(black_box(&small), black_box(|_: &String, value: &i32| *value > 0)))
     });
 }

--- a/benches/omit_by_keys.rs
+++ b/benches/omit_by_keys.rs
@@ -3,14 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_omit_by_keys(c: &mut Criterion) {
-    let map = support::numeric_map(2_048);
     let keys = vec![
-        String::from("key-10"),
-        String::from("key-20"),
-        String::from("key-30"),
-        String::from("key-40"),
+        String::from("key-10"), String::from("key-20"),
+        String::from("key-30"), String::from("key-40"),
     ];
-    c.bench_function("omit_by_keys", |b| {
+
+    let map = support::numeric_map(2_048);
+    c.bench_function("omit_by_keys/medium", |b| {
         b.iter(|| ld::omit_by_keys(black_box(&map), black_box(&keys)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("omit_by_keys/small", |b| {
+        b.iter(|| ld::omit_by_keys(black_box(&small), black_box(&keys)))
     });
 }

--- a/benches/omit_by_values.rs
+++ b/benches/omit_by_values.rs
@@ -3,9 +3,14 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_omit_by_values(c: &mut Criterion) {
-    let map = support::numeric_map(2_048);
     let values = vec![-1, 0, 1];
-    c.bench_function("omit_by_values", |b| {
+    let map = support::numeric_map(2_048);
+    c.bench_function("omit_by_values/medium", |b| {
         b.iter(|| ld::omit_by_values(black_box(&map), black_box(&values)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("omit_by_values/small", |b| {
+        b.iter(|| ld::omit_by_values(black_box(&small), black_box(&values)))
     });
 }

--- a/benches/partition_by.rs
+++ b/benches/partition_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_partition_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("partition_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("partition_by/people/increasing", |b| {
         b.iter(|| {
             ld::partition_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age / 10),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("partition_by/people/equal", |b| {
+        b.iter(|| {
+            ld::partition_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age / 10),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("partition_by/int_vec", |b| {
+        b.iter(|| ld::partition_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/pascal_case.rs
+++ b/benches/pascal_case.rs
@@ -4,7 +4,17 @@ use lowdash as ld;
 
 pub fn benchmark_pascal_case(c: &mut Criterion) {
     let input = support::mixed_identifier();
-    c.bench_function("pascal_case", |b| {
+    c.bench_function("pascal_case/mixed_identifier", |b| {
         b.iter(|| ld::pascal_case(black_box(input)))
+    });
+
+    let sentence = support::long_sentence();
+    c.bench_function("pascal_case/long_sentence", |b| {
+        b.iter(|| ld::pascal_case(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("pascal_case/short", |b| {
+        b.iter(|| ld::pascal_case(black_box(short)))
     });
 }

--- a/benches/percentile.rs
+++ b/benches/percentile.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_percentile(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("percentile", |b| {
-        b.iter(|| ld::percentile(black_box(&collection), black_box(95.0)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("percentile/int_vec/95", |b| {
+        b.iter(|| ld::percentile(black_box(&ints), black_box(95.0)))
+    });
+
+    c.bench_function("percentile/int_vec/50", |b| {
+        b.iter(|| ld::percentile(black_box(&ints), black_box(50.0)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("percentile/float_vec/95", |b| {
+        b.iter(|| ld::percentile(black_box(&floats), black_box(95.0)))
     });
 }

--- a/benches/permutation.rs
+++ b/benches/permutation.rs
@@ -3,7 +3,12 @@ use lowdash as ld;
 
 pub fn benchmark_permutation(c: &mut Criterion) {
     let items = vec![1, 2, 3, 4, 5, 6, 7];
-    c.bench_function("permutation", |b| {
-        b.iter(|| ld::permutation(black_box(&items)))
+    c.bench_function("permutation/7", |b| {
+        b.iter(|| ld::permutation(black_box(&items), black_box(7)))
+    });
+
+    let small = vec![1, 2, 3, 4];
+    c.bench_function("permutation/4", |b| {
+        b.iter(|| ld::permutation(black_box(&small), black_box(4)))
     });
 }

--- a/benches/pick_by.rs
+++ b/benches/pick_by.rs
@@ -4,12 +4,12 @@ use lowdash as ld;
 
 pub fn benchmark_pick_by(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("pick_by", |b| {
-        b.iter(|| {
-            ld::pick_by(
-                black_box(&map),
-                black_box(|_: &String, value: &i32| *value > 0),
-            )
-        })
+    c.bench_function("pick_by/medium", |b| {
+        b.iter(|| ld::pick_by(black_box(&map), black_box(|_: &String, value: &i32| *value > 0)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("pick_by/small", |b| {
+        b.iter(|| ld::pick_by(black_box(&small), black_box(|_: &String, value: &i32| *value > 0)))
     });
 }

--- a/benches/pick_by_keys.rs
+++ b/benches/pick_by_keys.rs
@@ -3,14 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_pick_by_keys(c: &mut Criterion) {
-    let map = support::numeric_map(2_048);
     let keys = vec![
-        String::from("key-10"),
-        String::from("key-20"),
-        String::from("key-30"),
-        String::from("key-40"),
+        String::from("key-10"), String::from("key-20"),
+        String::from("key-30"), String::from("key-40"),
     ];
-    c.bench_function("pick_by_keys", |b| {
+
+    let map = support::numeric_map(2_048);
+    c.bench_function("pick_by_keys/medium", |b| {
         b.iter(|| ld::pick_by_keys(black_box(&map), black_box(&keys)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("pick_by_keys/small", |b| {
+        b.iter(|| ld::pick_by_keys(black_box(&small), black_box(&keys)))
     });
 }

--- a/benches/pick_by_values.rs
+++ b/benches/pick_by_values.rs
@@ -3,9 +3,14 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_pick_by_values(c: &mut Criterion) {
-    let map = support::numeric_map(2_048);
     let values = vec![-1, 0, 1];
-    c.bench_function("pick_by_values", |b| {
+    let map = support::numeric_map(2_048);
+    c.bench_function("pick_by_values/medium", |b| {
         b.iter(|| ld::pick_by_values(black_box(&map), black_box(&values)))
+    });
+
+    let small = support::numeric_map(64);
+    c.bench_function("pick_by_values/small", |b| {
+        b.iter(|| ld::pick_by_values(black_box(&small), black_box(&values)))
     });
 }

--- a/benches/product.rs
+++ b/benches/product.rs
@@ -2,8 +2,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_product(c: &mut Criterion) {
-    let collection: Vec<f64> = (0..128).map(|i| 1.0 + (i % 5) as f64 / 100.0).collect();
-    c.bench_function("product", |b| {
-        b.iter(|| ld::product(black_box(&collection)))
-    });
+    let ints: Vec<f64> = (0..128).map(|i| 1.0 + (i % 5) as f64 / 100.0).collect();
+    c.bench_function("product/small", |b| b.iter(|| ld::product(black_box(&ints))));
+
+    let large: Vec<f64> = (0..4_096).map(|i| 1.0 + (i % 3) as f64 / 100.0).collect();
+    c.bench_function("product/large", |b| b.iter(|| ld::product(black_box(&large))));
 }

--- a/benches/product_by.rs
+++ b/benches/product_by.rs
@@ -3,12 +3,32 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_product_by(c: &mut Criterion) {
-    let collection = support::people(256);
-    c.bench_function("product_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("product_by/people/increasing", |b| {
         b.iter(|| {
             ld::product_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| 1.0 + (person.age % 3) as f64 / 100.0),
+            )
+        })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("product_by/people/equal", |b| {
+        b.iter(|| {
+            ld::product_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| 1.0 + (person.age % 3) as f64 / 100.0),
+            )
+        })
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("product_by/int_vec", |b| {
+        b.iter(|| {
+            ld::product_by(
+                black_box(&ints),
+                black_box(|x: &i32| 1.0 + (*x).unsigned_abs() as f64 / 100.0),
             )
         })
     });

--- a/benches/random_string.rs
+++ b/benches/random_string.rs
@@ -2,7 +2,15 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_random_string(c: &mut Criterion) {
-    c.bench_function("random_string", |b| {
+    c.bench_function("random_string/64", |b| {
         b.iter(|| ld::random_string(black_box(64), black_box(ld::common::ALPHANUMERIC_CHARSET)))
+    });
+
+    c.bench_function("random_string/256", |b| {
+        b.iter(|| ld::random_string(black_box(256), black_box(ld::common::ALPHANUMERIC_CHARSET)))
+    });
+
+    c.bench_function("random_string/8", |b| {
+        b.iter(|| ld::random_string(black_box(8), black_box(ld::common::ALPHANUMERIC_CHARSET)))
     });
 }

--- a/benches/range.rs
+++ b/benches/range.rs
@@ -2,5 +2,7 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_range(c: &mut Criterion) {
-    c.bench_function("range", |b| b.iter(|| ld::range(black_box(10_000))));
+    c.bench_function("range/10000", |b| b.iter(|| ld::range(black_box(10_000))));
+
+    c.bench_function("range/100", |b| b.iter(|| ld::range(black_box(100))));
 }

--- a/benches/range_from.rs
+++ b/benches/range_from.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_range_from(c: &mut Criterion) {
-    c.bench_function("range_from", |b| {
+    c.bench_function("range_from/500-10000", |b| {
         b.iter(|| ld::range_from(black_box(500_i32), black_box(10_000)))
+    });
+
+    c.bench_function("range_from/0-100", |b| {
+        b.iter(|| ld::range_from(black_box(0_i32), black_box(100)))
     });
 }

--- a/benches/range_with_steps.rs
+++ b/benches/range_with_steps.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_range_with_steps(c: &mut Criterion) {
-    c.bench_function("range_with_steps", |b| {
+    c.bench_function("range_with_steps/0-10000-3", |b| {
         b.iter(|| ld::range_with_steps(black_box(0_i32), black_box(10_000_i32), black_box(3_i32)))
+    });
+
+    c.bench_function("range_with_steps/0-100-1", |b| {
+        b.iter(|| ld::range_with_steps(black_box(0_i32), black_box(100_i32), black_box(1_i32)))
     });
 }

--- a/benches/reduce.rs
+++ b/benches/reduce.rs
@@ -3,13 +3,24 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_reduce(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("reduce", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("reduce/int_vec", |b| {
         b.iter(|| {
             ld::reduce(
-                black_box(&collection),
+                black_box(&ints),
                 black_box(|acc, value: &i32, _| acc + value),
                 black_box(0_i32),
+            )
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("reduce/float_vec", |b| {
+        b.iter(|| {
+            ld::reduce(
+                black_box(&floats),
+                black_box(|acc, value: &f64, _| acc + value),
+                black_box(0.0_f64),
             )
         })
     });

--- a/benches/reduce_right.rs
+++ b/benches/reduce_right.rs
@@ -3,13 +3,24 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_reduce_right(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("reduce_right", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("reduce_right/int_vec", |b| {
         b.iter(|| {
             ld::reduce_right(
-                black_box(&collection),
+                black_box(&ints),
                 black_box(|acc, value: &i32, _| acc + value),
                 black_box(0_i32),
+            )
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("reduce_right/float_vec", |b| {
+        b.iter(|| {
+            ld::reduce_right(
+                black_box(&floats),
+                black_box(|acc, value: &f64, _| acc + value),
+                black_box(0.0_f64),
             )
         })
     });

--- a/benches/reject.rs
+++ b/benches/reject.rs
@@ -3,13 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_reject(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("reject", |b| {
-        b.iter(|| {
-            ld::reject(
-                black_box(&collection),
-                black_box(|value: &i32, _| *value % 2 == 0),
-            )
-        })
+    let ints = support::int_vec(4_096);
+    c.bench_function("reject/int_vec", |b| {
+        b.iter(|| ld::reject(black_box(&ints), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("reject/duplicate_int_vec", |b| {
+        b.iter(|| ld::reject(black_box(&duplicates), black_box(|value: &i32, _| *value % 2 == 0)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("reject/float_vec", |b| {
+        b.iter(|| ld::reject(black_box(&floats), black_box(|value: &f64, _| *value > 0.0)))
     });
 }

--- a/benches/reject_map.rs
+++ b/benches/reject_map.rs
@@ -3,12 +3,22 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_reject_map(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("reject_map", |b| {
+    let ints = support::int_vec(4_096);
+    c.bench_function("reject_map/int_vec", |b| {
         b.iter(|| {
             ld::reject_map(
-                black_box(&collection),
+                black_box(&ints),
                 black_box(|value: &i32, index| (*value + index as i32, index % 2 == 0)),
+            )
+        })
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("reject_map/float_vec", |b| {
+        b.iter(|| {
+            ld::reject_map(
+                black_box(&floats),
+                black_box(|value: &f64, index| (*value + index as f64, index % 2 == 0)),
             )
         })
     });

--- a/benches/repeat.rs
+++ b/benches/repeat.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_repeat(c: &mut Criterion) {
-    c.bench_function("repeat", |b| {
+    c.bench_function("repeat/2048/7", |b| {
         b.iter(|| ld::repeat(black_box(2_048), black_box(7_i32)))
+    });
+
+    c.bench_function("repeat/512/3.14", |b| {
+        b.iter(|| ld::repeat(black_box(512), black_box(3.14_f64)))
     });
 }

--- a/benches/repeat_by.rs
+++ b/benches/repeat_by.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_repeat_by(c: &mut Criterion) {
-    c.bench_function("repeat_by", |b| {
+    c.bench_function("repeat_by/2048", |b| {
         b.iter(|| ld::repeat_by(black_box(2_048), black_box(|index| index as i32 * 2)))
+    });
+
+    c.bench_function("repeat_by/512", |b| {
+        b.iter(|| ld::repeat_by(black_box(512), black_box(|index| index as f64 * 1.5)))
     });
 }

--- a/benches/replace.rs
+++ b/benches/replace.rs
@@ -3,15 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_replace(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("replace", |b| {
-        b.iter(|| {
-            ld::replace(
-                black_box(&collection),
-                black_box(7),
-                black_box(999),
-                black_box(64),
-            )
-        })
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("replace/duplicate_int_vec", |b| {
+        b.iter(|| ld::replace(black_box(&duplicates), black_box(7), black_box(999), black_box(64)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("replace/int_vec", |b| {
+        b.iter(|| ld::replace(black_box(&ints), black_box(7), black_box(999), black_box(64)))
     });
 }

--- a/benches/replace_all.rs
+++ b/benches/replace_all.rs
@@ -3,8 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_replace_all(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("replace_all", |b| {
-        b.iter(|| ld::replace_all(black_box(&collection), black_box(7), black_box(999)))
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("replace_all/duplicate_int_vec", |b| {
+        b.iter(|| ld::replace_all(black_box(&duplicates), black_box(7), black_box(999)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("replace_all/int_vec", |b| {
+        b.iter(|| ld::replace_all(black_box(&ints), black_box(7), black_box(999)))
     });
 }

--- a/benches/reverse.rs
+++ b/benches/reverse.rs
@@ -3,8 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_reverse(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("reverse", |b| {
-        b.iter(|| ld::reverse(black_box(&collection)))
-    });
+    let ints = support::int_vec(4_096);
+    c.bench_function("reverse/int_vec", |b| b.iter(|| ld::reverse(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("reverse/float_vec", |b| b.iter(|| ld::reverse(black_box(&floats))));
 }

--- a/benches/sample.rs
+++ b/benches/sample.rs
@@ -3,6 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_sample(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("sample", |b| b.iter(|| ld::sample(black_box(&collection))));
+    let ints = support::int_vec(4_096);
+    c.bench_function("sample/int_vec", |b| b.iter(|| ld::sample(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("sample/float_vec", |b| b.iter(|| ld::sample(black_box(&floats))));
 }

--- a/benches/samples.rs
+++ b/benches/samples.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_samples(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("samples", |b| {
-        b.iter(|| ld::samples(black_box(&collection), black_box(64)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("samples/int_vec/64", |b| {
+        b.iter(|| ld::samples(black_box(&ints), black_box(64)))
+    });
+
+    c.bench_function("samples/int_vec/1", |b| {
+        b.iter(|| ld::samples(black_box(&ints), black_box(1)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("samples/float_vec/64", |b| {
+        b.iter(|| ld::samples(black_box(&floats), black_box(64)))
     });
 }

--- a/benches/shuffle.rs
+++ b/benches/shuffle.rs
@@ -3,8 +3,9 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_shuffle(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("shuffle", |b| {
-        b.iter(|| ld::shuffle(black_box(&collection)))
-    });
+    let ints = support::int_vec(4_096);
+    c.bench_function("shuffle/int_vec", |b| b.iter(|| ld::shuffle(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("shuffle/float_vec", |b| b.iter(|| ld::shuffle(black_box(&floats))));
 }

--- a/benches/slice.rs
+++ b/benches/slice.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_slice(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("slice", |b| {
-        b.iter(|| ld::slice(black_box(&collection), black_box(-1_024), black_box(-128)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("slice/int_vec/neg", |b| {
+        b.iter(|| ld::slice(black_box(&ints), black_box(-1_024), black_box(-128)))
+    });
+
+    c.bench_function("slice/int_vec/pos", |b| {
+        b.iter(|| ld::slice(black_box(&ints), black_box(128), black_box(512)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("slice/float_vec/neg", |b| {
+        b.iter(|| ld::slice(black_box(&floats), black_box(-1_024), black_box(-128)))
     });
 }

--- a/benches/slice_to_map.rs
+++ b/benches/slice_to_map.rs
@@ -3,12 +3,32 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_slice_to_map(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("slice_to_map", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("slice_to_map/people/increasing", |b| {
         b.iter(|| {
             ld::slice_to_map(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| (person.name.clone(), person.age)),
+            )
+        })
+    });
+
+    let people_shuffled = support::people_shuffled(4_096);
+    c.bench_function("slice_to_map/people/shuffled", |b| {
+        b.iter(|| {
+            ld::slice_to_map(
+                black_box(&people_shuffled),
+                black_box(|person: &support::Person| (person.name.clone(), person.age)),
+            )
+        })
+    });
+
+    let timed_records = support::timed_records(4_096);
+    c.bench_function("slice_to_map/timed_records/increasing", |b| {
+        b.iter(|| {
+            ld::slice_to_map(
+                black_box(&timed_records),
+                black_box(|record: &support::TimedRecord| (record.name.clone(), record.timestamp)),
             )
         })
     });

--- a/benches/snake_case.rs
+++ b/benches/snake_case.rs
@@ -4,7 +4,17 @@ use lowdash as ld;
 
 pub fn benchmark_snake_case(c: &mut Criterion) {
     let input = support::mixed_identifier();
-    c.bench_function("snake_case", |b| {
+    c.bench_function("snake_case/mixed_identifier", |b| {
         b.iter(|| ld::snake_case(black_box(input)))
+    });
+
+    let sentence = support::long_sentence();
+    c.bench_function("snake_case/long_sentence", |b| {
+        b.iter(|| ld::snake_case(black_box(sentence)))
+    });
+
+    let short = support::short_string();
+    c.bench_function("snake_case/short", |b| {
+        b.iter(|| ld::snake_case(black_box(short)))
     });
 }

--- a/benches/splice.rs
+++ b/benches/splice.rs
@@ -3,9 +3,13 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_splice(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    let elements = vec![7, 8, 9, 10];
-    c.bench_function("splice", |b| {
-        b.iter(|| ld::splice(black_box(&collection), black_box(128), black_box(&elements)))
+    let ints = support::int_vec(4_096);
+    let replacement = vec![999; 128];
+    c.bench_function("splice/int_vec/remove", |b| {
+        b.iter(|| ld::splice(black_box(&ints), black_box(0), black_box(&[] as &[i32])))
+    });
+
+    c.bench_function("splice/int_vec/replace", |b| {
+        b.iter(|| ld::splice(black_box(&ints), black_box(256), black_box(&replacement)))
     });
 }

--- a/benches/subset.rs
+++ b/benches/subset.rs
@@ -3,8 +3,17 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_subset(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("subset", |b| {
-        b.iter(|| ld::subset(black_box(&collection), black_box(-512), black_box(256)))
+    let ints = support::int_vec(4_096);
+    c.bench_function("subset/int_vec/neg", |b| {
+        b.iter(|| ld::subset(black_box(&ints), black_box(-512), black_box(256)))
+    });
+
+    c.bench_function("subset/int_vec/pos", |b| {
+        b.iter(|| ld::subset(black_box(&ints), black_box(100), black_box(200)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("subset/float_vec/neg", |b| {
+        b.iter(|| ld::subset(black_box(&floats), black_box(-512), black_box(256)))
     });
 }

--- a/benches/substring.rs
+++ b/benches/substring.rs
@@ -4,7 +4,16 @@ use lowdash as ld;
 
 pub fn benchmark_substring(c: &mut Criterion) {
     let input = support::substring_input();
-    c.bench_function("substring", |b| {
+    c.bench_function("substring/input/neg", |b| {
         b.iter(|| ld::substring(black_box(input), black_box(-24), black_box(18)))
+    });
+
+    c.bench_function("substring/input/pos", |b| {
+        b.iter(|| ld::substring(black_box(input), black_box(2), black_box(10)))
+    });
+
+    let sentence = support::long_sentence();
+    c.bench_function("substring/sentence/pos", |b| {
+        b.iter(|| ld::substring(black_box(sentence), black_box(6), black_box(20)))
     });
 }

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -3,6 +3,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_sum(c: &mut Criterion) {
-    let collection = support::int_vec(4_096);
-    c.bench_function("sum", |b| b.iter(|| ld::sum(black_box(&collection))));
+    let ints = support::int_vec(4_096);
+    c.bench_function("sum/int_vec", |b| b.iter(|| ld::sum(black_box(&ints))));
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("sum/float_vec", |b| b.iter(|| ld::sum(black_box(&floats))));
+
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("sum/duplicate_int_vec", |b| b.iter(|| ld::sum(black_box(&duplicates))));
 }

--- a/benches/sum_by.rs
+++ b/benches/sum_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_sum_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("sum_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("sum_by/people/increasing", |b| {
         b.iter(|| {
             ld::sum_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("sum_by/people/equal", |b| {
+        b.iter(|| {
+            ld::sum_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age),
+            )
+        })
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("sum_by/int_vec", |b| {
+        b.iter(|| ld::sum_by(black_box(&ints), black_box(|x: &i32| *x)))
     });
 }

--- a/benches/support.rs
+++ b/benches/support.rs
@@ -222,3 +222,68 @@ pub fn long_sentence() -> &'static str {
 pub fn substring_input() -> &'static str {
     "Hello\0Rustaceans_and-Benchmarkers42"
 }
+
+pub fn int_vec_descending(len: usize) -> Vec<i32> {
+    (0..len as i32).rev().map(|i| (i % 97) - 48).collect()
+}
+
+pub fn int_vec_shuffled(len: usize) -> Vec<i32> {
+    let mut v = int_vec(len);
+    for i in (1..v.len()).rev() {
+        let j = (i * 31 + 7) % (i + 1);
+        v.swap(i, j);
+    }
+    v
+}
+
+pub fn people_same_age(len: usize) -> Vec<Person> {
+    (0..len)
+        .map(|i| Person {
+            id: i,
+            name: format!("person-{}", i % 64),
+            age: 30,
+        })
+        .collect()
+}
+
+pub fn people_descending(len: usize) -> Vec<Person> {
+    (0..len)
+        .map(|i| Person {
+            id: i,
+            name: format!("person-{}", (len - 1 - i) % 64),
+            age: 20 + ((len - 1 - i) % 50) as u32,
+        })
+        .collect()
+}
+
+pub fn people_shuffled(len: usize) -> Vec<Person> {
+    let mut v = people(len);
+    for i in (1..v.len()).rev() {
+        let j = (i * 31 + 7) % (i + 1);
+        v.swap(i, j);
+    }
+    v
+}
+
+pub fn short_string() -> &'static str {
+    "hello world"
+}
+
+pub fn time_vec_descending(len: usize) -> Vec<std::time::SystemTime> {
+    (0..len)
+        .map(|i| std::time::UNIX_EPOCH + std::time::Duration::from_secs(((len - i) * 11) as u64))
+        .collect()
+}
+
+pub fn time_vec_equal(len: usize) -> Vec<std::time::SystemTime> {
+    vec![std::time::UNIX_EPOCH + std::time::Duration::from_secs(17); len]
+}
+
+pub fn time_vec_shuffled(len: usize) -> Vec<std::time::SystemTime> {
+    let mut v = time_vec(len);
+    for i in (1..v.len()).rev() {
+        let j = (i * 31 + 7) % (i + 1);
+        v.swap(i, j);
+    }
+    v
+}

--- a/benches/times.rs
+++ b/benches/times.rs
@@ -2,7 +2,11 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_times(c: &mut Criterion) {
-    c.bench_function("times", |b| {
+    c.bench_function("times/2048", |b| {
         b.iter(|| ld::times(black_box(2_048), black_box(|index| index as i32 * 2)))
+    });
+
+    c.bench_function("times/128", |b| {
+        b.iter(|| ld::times(black_box(128), black_box(|index| index as f64)))
     });
 }

--- a/benches/to_pairs.rs
+++ b/benches/to_pairs.rs
@@ -4,5 +4,8 @@ use lowdash as ld;
 
 pub fn benchmark_to_pairs(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    c.bench_function("to_pairs", |b| b.iter(|| ld::to_pairs(black_box(&map))));
+    c.bench_function("to_pairs/medium", |b| b.iter(|| ld::to_pairs(black_box(&map))));
+
+    let small = support::numeric_map(64);
+    c.bench_function("to_pairs/small", |b| b.iter(|| ld::to_pairs(black_box(&small))));
 }

--- a/benches/uniq.rs
+++ b/benches/uniq.rs
@@ -3,6 +3,18 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_uniq(c: &mut Criterion) {
-    let collection = support::duplicate_int_vec(4_096);
-    c.bench_function("uniq", |b| b.iter(|| ld::uniq(black_box(&collection))));
+    let duplicates = support::duplicate_int_vec(4_096);
+    c.bench_function("uniq/duplicate_int_vec", |b| {
+        b.iter(|| ld::uniq(black_box(&duplicates)))
+    });
+
+    let ints = support::int_vec(4_096);
+    c.bench_function("uniq/int_vec", |b| {
+        b.iter(|| ld::uniq(black_box(&ints)))
+    });
+
+    let floats = support::float_vec(4_096);
+    c.bench_function("uniq/float_vec", |b| {
+        b.iter(|| ld::uniq(black_box(&floats)))
+    });
 }

--- a/benches/uniq_by.rs
+++ b/benches/uniq_by.rs
@@ -3,13 +3,28 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_uniq_by(c: &mut Criterion) {
-    let collection = support::people(2_048);
-    c.bench_function("uniq_by", |b| {
+    let people_increasing = support::people(4_096);
+    c.bench_function("uniq_by/people/increasing", |b| {
         b.iter(|| {
             ld::uniq_by(
-                black_box(&collection),
+                black_box(&people_increasing),
                 black_box(|person: &support::Person| person.age),
             )
         })
+    });
+
+    let people_same = support::people_same_age(4_096);
+    c.bench_function("uniq_by/people/equal", |b| {
+        b.iter(|| {
+            ld::uniq_by(
+                black_box(&people_same),
+                black_box(|person: &support::Person| person.age),
+            )
+        })
+    });
+
+    let ints = support::duplicate_int_vec(4_096);
+    c.bench_function("uniq_by/int_vec", |b| {
+        b.iter(|| ld::uniq_by(black_box(&ints), black_box(|x: &i32| *x % 8)))
     });
 }

--- a/benches/uniq_keys.rs
+++ b/benches/uniq_keys.rs
@@ -5,5 +5,9 @@ use lowdash as ld;
 pub fn benchmark_uniq_keys(c: &mut Criterion) {
     let maps = support::numeric_maps(8, 256);
     let refs = support::map_refs(&maps);
-    c.bench_function("uniq_keys", |b| b.iter(|| ld::uniq_keys(black_box(&refs))));
+    c.bench_function("uniq_keys/medium", |b| b.iter(|| ld::uniq_keys(black_box(&refs))));
+
+    let small_maps = support::numeric_maps(4, 32);
+    let small_refs = support::map_refs(&small_maps);
+    c.bench_function("uniq_keys/small", |b| b.iter(|| ld::uniq_keys(black_box(&small_refs))));
 }

--- a/benches/uniq_values.rs
+++ b/benches/uniq_values.rs
@@ -5,7 +5,9 @@ use lowdash as ld;
 pub fn benchmark_uniq_values(c: &mut Criterion) {
     let maps = support::numeric_maps(8, 256);
     let refs = support::map_refs(&maps);
-    c.bench_function("uniq_values", |b| {
-        b.iter(|| ld::uniq_values(black_box(&refs)))
-    });
+    c.bench_function("uniq_values/medium", |b| b.iter(|| ld::uniq_values(black_box(&refs))));
+
+    let small_maps = support::numeric_maps(4, 32);
+    let small_refs = support::map_refs(&small_maps);
+    c.bench_function("uniq_values/small", |b| b.iter(|| ld::uniq_values(black_box(&small_refs))));
 }

--- a/benches/value_or.rs
+++ b/benches/value_or.rs
@@ -4,8 +4,13 @@ use lowdash as ld;
 
 pub fn benchmark_value_or(c: &mut Criterion) {
     let map = support::numeric_map(2_048);
-    let key = String::from("missing");
-    c.bench_function("value_or", |b| {
-        b.iter(|| ld::value_or(black_box(&map), black_box(&key), black_box(-1)))
+    let missing = String::from("missing");
+    c.bench_function("value_or/map/missing", |b| {
+        b.iter(|| ld::value_or(black_box(&map), black_box(&missing), black_box(-1)))
+    });
+
+    let existing = String::from("key-1024");
+    c.bench_function("value_or/map/existing", |b| {
+        b.iter(|| ld::value_or(black_box(&map), black_box(&existing), black_box(-1)))
     });
 }

--- a/benches/values.rs
+++ b/benches/values.rs
@@ -5,5 +5,9 @@ use lowdash as ld;
 pub fn benchmark_values(c: &mut Criterion) {
     let maps = support::numeric_maps(8, 256);
     let refs = support::map_refs(&maps);
-    c.bench_function("values", |b| b.iter(|| ld::values(black_box(&refs))));
+    c.bench_function("values/medium", |b| b.iter(|| ld::values(black_box(&refs))));
+
+    let small_maps = support::numeric_maps(4, 32);
+    let small_refs = support::map_refs(&small_maps);
+    c.bench_function("values/small", |b| b.iter(|| ld::values(black_box(&small_refs))));
 }

--- a/benches/words.rs
+++ b/benches/words.rs
@@ -3,6 +3,12 @@ use criterion::{black_box, Criterion};
 use lowdash as ld;
 
 pub fn benchmark_words(c: &mut Criterion) {
-    let input = support::long_sentence();
-    c.bench_function("words", |b| b.iter(|| ld::words(black_box(input))));
+    let sentence = support::long_sentence();
+    c.bench_function("words/long_sentence", |b| b.iter(|| ld::words(black_box(sentence))));
+
+    let input = support::mixed_identifier();
+    c.bench_function("words/mixed_identifier", |b| b.iter(|| ld::words(black_box(input))));
+
+    let short = support::short_string();
+    c.bench_function("words/short", |b| b.iter(|| ld::words(black_box(short))));
 }


### PR DESCRIPTION
The Python script in the `tabularize results` step was not indented properly inside the YAML block scalar (`|`). The script content started at column 1, which caused the YAML parser to interpret `import os, re` as a YAML key rather than literal text.

Indented the entire Python script to match the block scalar indentation level so YAML parses it correctly.