### PR TITLE
perf: build kebab_case output String directly, avoid Vec<String> and join

### DIFF
--- a/src/kebab_case.rs
+++ b/src/kebab_case.rs
@@ -24,7 +24,7 @@ pub fn kebab_case(str_input: &str) -> String {
         return String::new();
     }
 
-    let mut words = Vec::new();
+    let mut result = String::with_capacity(str_input.len());
     let mut current_word = String::new();
     let mut prev_char = ' ';
 
@@ -36,13 +36,19 @@ pub fn kebab_case(str_input: &str) -> String {
                 || prev_char == '_')
         {
             if !current_word.is_empty() {
-                words.push(current_word.to_lowercase());
+                if !result.is_empty() {
+                    result.push('-');
+                }
+                result.push_str(&current_word.to_lowercase());
                 current_word.clear();
             }
             current_word.push(c);
         } else if c.is_whitespace() || c == '-' || c == '_' {
             if !current_word.is_empty() {
-                words.push(current_word.to_lowercase());
+                if !result.is_empty() {
+                    result.push('-');
+                }
+                result.push_str(&current_word.to_lowercase());
                 current_word.clear();
             }
         } else {
@@ -52,10 +58,13 @@ pub fn kebab_case(str_input: &str) -> String {
     }
 
     if !current_word.is_empty() {
-        words.push(current_word.to_lowercase());
+        if !result.is_empty() {
+            result.push('-');
+        }
+        result.push_str(&current_word.to_lowercase());
     }
 
-    words.join("-")
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace intermediate `Vec<String>` + `words.join(-)` with direct writes to a pre-allocated output `String`. Same optimization applied to snake_case (#155).

**Benchmark (Criterion, 500 samples, 10s measurement):**
| Variant | Before | After | Change |
|---|---|---|---|
| mixed_identifier | 491 ns | 448 ns | **–9%** (within noise) |
| long_sentence | 964 ns | 790 ns | **–18%** |
| short | 168 ns | 132 ns | **–21%** |

All 18 kebab_case tests pass. Clippy + fmt clean.