### PR TITLE
perf: early return in replace when n==0 to skip loop

### DIFF
--- a/src/replace.rs
+++ b/src/replace.rs
@@ -55,9 +55,12 @@ pub fn replace<T>(collection: &[T], old: T, new: T, mut n: usize) -> Vec<T>
 where
     T: PartialEq + Clone,
 {
+    if n == 0 {
+        return collection.to_vec();
+    }
     let mut result = collection.to_vec();
     for item in &mut result {
-        if *item == old && n > 0 {
+        if *item == old {
             *item = new.clone();
             n -= 1;
             if n == 0 {


### PR DESCRIPTION
Add early return guard when `n == 0` to skip the element comparison loop entirely. Also removes the redundant `&& n > 0` check per iteration, since n is guaranteed > 0 after the guard.

Avoids \~4096 comparisons when `n == 0` on a 4K collection. All 21 replace/replace_all tests pass. Clippy + fmt clean.