### PR TITLE
perf: avoid redundant clone in uniq_by

### DIFF
--- a/src/uniq_by.rs
+++ b/src/uniq_by.rs
@@ -68,7 +68,7 @@ where
     for item in collection {
         let key = iteratee(item);
         if !seen.contains(&key) {
-            seen.push(key.clone());
+            seen.push(key);
             result.push(item.clone());
         }
     }


### PR DESCRIPTION
The key returned by the iteratee is already a fresh value. Pushing `key` directly instead of `key.clone()` saves one clone per unique element. The benchmark shows no regression (keys are cheap integers); the savings would be visible with expensive key types like `String`.

All 14 uniq_by tests pass. Clippy + fmt clean.