### PR TITLE
perf: build pascal_case output String directly, avoid Vec<char> per word

### DIFF
--- a/src/pascal_case.rs
+++ b/src/pascal_case.rs
@@ -22,17 +22,23 @@ pub fn pascal_case(str_input: &str) -> String {
         return String::new();
     }
 
-    str_input
-        .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
-        .filter(|s| !s.is_empty())
-        .map(|word| {
-            let mut chars: Vec<char> = word.chars().collect();
-            if let Some(first) = chars.first_mut() {
-                *first = first.to_uppercase().next().unwrap_or(*first);
+    let mut result = String::with_capacity(str_input.len());
+    let mut in_word = false;
+
+    for c in str_input.chars() {
+        if c.is_whitespace() || c == '-' || c == '_' {
+            in_word = false;
+        } else {
+            if !in_word {
+                result.push(c.to_uppercase().next().unwrap_or(c));
+                in_word = true;
+            } else {
+                result.push(c);
             }
-            chars.into_iter().collect::<String>()
-        })
-        .collect()
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace `split` → `filter` → `map` (with per-word Vec<char> + collect) → `collect` pipeline with direct writes to a pre-allocated output String. Preserves exact behavior (first-char uppercase via to_uppercase().next()).

**Benchmark (Criterion, 500 samples, 10s measurement):**
| Variant | Before | After | Change |
|---|---|---|---|
| mixed_identifier | 883 ns | 156 ns | **–82%** |
| long_sentence | 1.98 µs | 332 ns | **–83%** |
| short | 269 ns | 58 ns | **–78%** |

All 15 pascal_case tests pass. Clippy + fmt clean.